### PR TITLE
Add support for RADIO_ADD_OFFSET #28

### DIFF
--- a/data_generator.py
+++ b/data_generator.py
@@ -117,6 +117,7 @@ class DataGenerator(Sequence):
             if os.path.isfile(file) and file.endswith('.nc'):
                 with nc.Dataset(file, 'r') as root:
                     if self.normalization == "minmax":
+                        # Take data bands from the NetCDF file, add offsets from S2 product metadata, scale pixel values by range.
                         data_bands = np.asarray([np.asarray(root[f]) for i, f in enumerate(self.features)])
                         data_bands = data_bands + (np.reshape(self.offsets, (len(self.features), 1, 1)) / 65535) 
                         data_bands = [(data_bands[i] - self.min_v[i]) / (self.max_v[i] - self.min_v[i]) for i, f

--- a/km_predict.py
+++ b/km_predict.py
@@ -197,7 +197,6 @@ class KMPredict(ulog.Loggable):
         return baseline
 
     def get_offset_list(self, filepath, features):
-
         tree = ET.parse(filepath)
         root = tree.getroot()
 
@@ -205,7 +204,7 @@ class KMPredict(ulog.Loggable):
         offset_list = root.find('.//Radiometric_Offset_List')
 
         if not offset_list:
-            offsets= np.zeros(len(features),)
+            offsets = np.zeros(len(features),)
             return offsets
             
         else:
@@ -215,7 +214,6 @@ class KMPredict(ulog.Loggable):
                     offsets.append(value)
 
             return np.array(offsets)
-        
 
     def sub_tile(self, path_out, aoi_geom):
         """

--- a/km_predict.py
+++ b/km_predict.py
@@ -37,6 +37,7 @@ from pkg_resources import parse_version
 import math
 import tensorflow as tf
 import urllib.request
+import xml.etree.ElementTree as ET
 
 
 class KMPredict(ulog.Loggable):
@@ -134,6 +135,13 @@ class KMPredict(ulog.Loggable):
         self.data_folder = d["folder_name"]
 
         self.product_safe = os.path.join(self.data_folder, str(self.product_name + ".SAFE"))
+        self.product_metadata = os.path.join(self.data_folder, str(self.product_name + ".SAFE"), "MTD_MSI%s.xml" % d["level_product"])
+
+        self.product_baseline = self.get_product_baseline(self.product_metadata)
+        self.offsets = self.get_offset_list(self.product_metadata, self.features)
+
+        # Access data
+
         self.weights_path = os.path.join(self.weights_folder, self.weights)
         self.prediction_product_path = os.path.join(self.predict_folder, self.product_name)
 
@@ -182,6 +190,33 @@ class KMPredict(ulog.Loggable):
             site = urllib.request.urlopen(url)
             urllib.request.urlretrieve(url, self.weights_path)
 
+    def get_product_baseline(self, filepath):
+        tree = ET.parse(filepath)
+        root = tree.getroot()
+        baseline = root.findall('.//PROCESSING_BASELINE')[0].text
+        return baseline
+
+    def get_offset_list(self, filepath, features):
+
+        tree = ET.parse(filepath)
+        root = tree.getroot()
+
+        offsets = [] 
+        offset_list = root.find('.//Radiometric_Offset_List')
+
+        if not offset_list:
+            offsets= np.zeros(len(features),)
+            return offsets
+            
+        else:
+            for child in offset_list:
+                value = int(child.text.strip()) if child.text else None
+                if value is not None:
+                    offsets.append(value)
+
+            return np.array(offsets)
+        
+
     def sub_tile(self, path_out, aoi_geom):
         """
         Execute cm-vsm sub-tiling process
@@ -207,6 +242,7 @@ class KMPredict(ulog.Loggable):
             cm_vsm_query += ["-g", self.aoi_geom]
 
         self.log.info("Splitting with CM-VSM: {}".format(cm_vsm_query))
+        self.log.info("Product processing baseline: %s" % self.product_baseline)
         with subprocess.Popen(cm_vsm_query, stdout=subprocess.PIPE, env=self.cm_vsm_env) as cm_vsm_process:
             for line in cm_vsm_process.stdout:
                 cm_vsm_output = line.decode("utf-8").rstrip("\n")
@@ -252,6 +288,7 @@ class KMPredict(ulog.Loggable):
                        'tile_size': self.tile_size,
                        'num_classes': len(self.classes),
                        'product_level': self.product,
+                       'offsets': self.offsets,
                        'shuffle': False
                        }
 

--- a/version.py
+++ b/version.py
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '2.2.0'
+__version__ = '2.3.0'
 min_cm_vsm_version = '0.2.6'
 
 # 2.2.0 - Bump km_predict version to make it compatible with Docker image version numbers.

--- a/version.py
+++ b/version.py
@@ -19,6 +19,7 @@
 __version__ = '2.3.0'
 min_cm_vsm_version = '0.2.6'
 
+# 2.3.0 - Support band offsets in S2 product metadata.
 # 2.2.0 - Bump km_predict version to make it compatible with Docker image version numbers.
 # 1.1.0 - Docker image no longer relies on Conda.
 # 1.0.5 - Calls to cm_vsm now less dependent on platform. Switch from miniconda to micromamba.


### PR DESCRIPTION
Bugfix for https://github.com/kappazeta/km_predict/issues/28

km_predict now verifies the presence of the radiometric_offset list in the MTD_MSIL1C.xml (or MTD_MSIL2A.xml) file. If the offsets are present, they are applied to the normalization parameters and band arrays for each band.